### PR TITLE
File name mismatch when using the Extract option #26

### DIFF
--- a/torcrawl.py
+++ b/torcrawl.py
@@ -169,8 +169,21 @@ def main():
 
     args = parser.parse_args()
 
+    now = datetime.datetime.now().strftime("%Y%m%d")
+
+    # Canonicalization of web url and create path for output.
+    website = ''
+    out_path = ''
+
+    if len(args.url) > 0:
+        website = url_canon(args.url, args.verbose)
+        if args.folder is not None:
+            out_path = folder(args.folder, args.verbose)
+        else:
+            out_path = folder(extract_domain(website), args.verbose)
+
     # Parse arguments to variables else initiate variables.
-    input_file = args.input if args.input else ''
+    input_file = args.input if args.input else (out_path + '/' + now + '_links.txt')
     output_file = args.output if args.output else ''
     c_depth = args.cdepth if args.cdepth else 0
     c_pause = args.cpause if args.cpause else 1
@@ -185,30 +198,17 @@ def main():
         check_ip()
         print(('## URL: ' + args.url))
 
-    website = ''
-    out_path = ''
-
-    # Canonicalization of web url and create path for output.
-    if len(args.url) > 0:
-        website = url_canon(args.url, args.verbose)
-        if args.folder is not None:
-            out_path = folder(args.folder, args.verbose)
-        else:
-            out_path = folder(extract_domain(website), args.verbose)
-
     if args.crawl:
         crawler = Crawler(website, c_depth, c_pause, out_path, args.log,
                           args.verbose)
         lst = crawler.crawl()
 
-        now = datetime.datetime.now().strftime("%Y%m%d")
-        with open(out_path + '/' + now + '_links.txt', 'w+', encoding='UTF-8') as file:
+        with open(input_file, 'w+', encoding='UTF-8') as file:
             for item in lst:
                 file.write(f"{item}\n")
         print(f"## File created on {os.getcwd()}/{out_path}/links.txt")
 
         if args.extract:
-            input_file = out_path + "/" + now + "_links.txt"
             extractor(website, args.crawl, output_file, input_file, out_path,
                       selection_yara)
     else:

--- a/torcrawl.py
+++ b/torcrawl.py
@@ -206,7 +206,7 @@ def main():
         with open(input_file, 'w+', encoding='UTF-8') as file:
             for item in lst:
                 file.write(f"{item}\n")
-        print(f"## File created on {os.getcwd()}/{out_path}/links.txt")
+        print(f"## File created on {os.getcwd()}/{input_file}")
 
         if args.extract:
             extractor(website, args.crawl, output_file, input_file, out_path,

--- a/torcrawl.py
+++ b/torcrawl.py
@@ -208,7 +208,7 @@ def main():
         print(f"## File created on {os.getcwd()}/{out_path}/links.txt")
 
         if args.extract:
-            input_file = out_path + "/links.txt"
+            input_file = out_path + "/" + now + "_links.txt"
             extractor(website, args.crawl, output_file, input_file, out_path,
                       selection_yara)
     else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed file name (by adding the date) and a bit of refactoring.

## Motivation and Context

 File name mismatch when using the Extract option #26

## How Has This Been Tested?

Tried to run command below.

```python 
python torcrawl.py -v -u https://pikvm.org -e -y t -c -d 2 -p 5
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
