### PR TITLE
33 request to modify url canonicalization for compatibility with onion sites

### DIFF
--- a/modules/checker.py
+++ b/modules/checker.py
@@ -17,11 +17,7 @@ def url_canon(website, verbose):
     :param verbose: Boolean - Verbose logging switch.
     :return: String 'website' - normalised result.
     """
-    if not website.startswith("https"):
-        # if not website.startswith("www."):
-        #     website = "www." + website
-        #     if verbose:
-        #         print(("## URL fixed: " + website))
+    if not website.startswith("http://") and not website.startswith("https://"):
         website = "https://" + website
         if verbose:
             print(("## URL fixed: " + website))

--- a/modules/tests/test_checker.py
+++ b/modules/tests/test_checker.py
@@ -19,7 +19,7 @@ class TestCheckFunctions(unittest.TestCase):
 
     def test_url_canon_001(self):
         """ url_canon unit test.
-        Returns true if the function successfully performs URL normalisation.
+        Returns true if the function successfully adds 'https://'.
         """
         url = 'torcrawl.com'
         expected = 'https://torcrawl.com'
@@ -29,9 +29,29 @@ class TestCheckFunctions(unittest.TestCase):
 
     def test_url_canon_002(self):
         """ url_canon unit test.
-        Returns true if the function successfully performs URL normalisation.
+        Returns true if the function successfully adds 'https://' over `www.`.
         """
         url = 'www.torcrawl.com'
+        expected = 'https://www.torcrawl.com'
+        result = url_canon(url, False)
+        self.assertEqual(expected, result,
+                         f'Test Fail:: expected = {expected}, got {result}')
+
+    def test_url_canon_003(self):
+        """ url_canon unit test.
+        Returns true if the function doesn't change `http://`.
+        """
+        url = 'http://www.torcrawl.com'
+        expected = 'http://www.torcrawl.com'
+        result = url_canon(url, False)
+        self.assertEqual(expected, result,
+                         f'Test Fail:: expected = {expected}, got {result}')
+
+    def test_url_canon_004(self):
+        """ url_canon unit test.
+        Returns true if the function doesn't change `https://`.
+        """
+        url = 'https://www.torcrawl.com'
         expected = 'https://www.torcrawl.com'
         result = url_canon(url, False)
         self.assertEqual(expected, result,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As described in #33, when `http://` was defined, the `url_canon()` wasn't parsing it correctly. Therefore, this PR closes #33.

## How Has This Been Tested?
`python torcrawl.py -w -u google.com -c -d 1 -p 1 -l -v -e`
`python torcrawl.py -w -u google.com -c -d 1 -p 1 -l -v`
`python torcrawl.py -w -u google.com -c -d 3 -l -v `

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
