### PR TITLE
Adding proxy option to be used instead of TOR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         run: pip install tox
       - name: Run tox
         run: tox -e py
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+      - name: SonarQube Cloud Scan
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build & Scan
 on:
   push:
     branches:
@@ -6,11 +6,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  sonarcloud:
-    name: SonarCloud
+  sonarqube:
+    name: SonarQube Cloud Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Python

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ $ torcrawl -v -u http://www.github.com/ -c -d 2 -p 2
 | -v           | --verbose           | Show more information about the progress                                               |
 | -u           | --url *.onion       | URL of Webpage to crawl or extract                                                     |
 | -w           | --without           | Without using TOR Network                                                              |
+| -px          | --proxy             | IP address for SOCKS5 proxy (Default: 127.0.0.1 for using TOR)                         |
+| -pr          | --proxyport         | Port for SOCKS5 proxy (Default: 9050)                                                  |
 | -f           | --folder            | The directory which will contain the generated files                                   |
 | **Extract**: |                     |                                                                                        |
 | -e           | --extract           | Extract page's code to terminal or file (Default: Terminal)                            |

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,3 +13,6 @@ sonar.sourceEncoding=UTF-8
 
 # Adding the coverage analysis path
 sonar.python.coverage.reportPaths=coverage.xml
+
+# Adding verbose logging of analysis
+sonar.verbose = true

--- a/torcrawl.py
+++ b/torcrawl.py
@@ -60,14 +60,13 @@ from modules.extractor import extractor
 
 
 # Set socket and connection with TOR network
-def connect_tor():
+def connect_tor(proxy_url, proxy_port):
     """ Connect to TOR via DNS resolution through a socket.
     :return: None or HTTPError.
     """
     try:
-        port = 9050
         # Set socks proxy and wrap the urllib module
-        socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS5, '127.0.0.1', port)
+        socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS5, proxy_url, proxy_port)
         socket.socket = socks.socksocket
 
         # Perform DNS resolution through the socket
@@ -166,6 +165,16 @@ def main():
         help='Check for keywords and only scrape documents that contain a '
              'match. \'h\' search whole html object. \'t\' search only the text.'
     )
+    parser.add_argument(
+        '-pr',
+        '--proxyport',
+        help='Port for SOCKS5 proxy',default=9050
+    )
+    parser.add_argument(
+        '-px',
+        '--proxy',
+        help='IP address for SOCKS5 proxy',default='127.0.0.1'
+    )
 
     args = parser.parse_args()
 
@@ -193,7 +202,7 @@ def main():
     # Connect to TOR
     if args.without is False:
         check_tor(args.verbose)
-        connect_tor()
+        connect_tor(args.proxy, args.proxyport)
 
     if args.verbose:
         check_ip()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Allow setting proxy URL and port via command line

## Motivation and Context
This commit introduces a new feature that enables users to specify proxy URL and port directly through command-line arguments.

## How Has This Been Tested?
Manual testing with various proxy URLs and ports

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
